### PR TITLE
Support building PAL region ROM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-pif.sm5.rom
+pif.sm5.ntsc.rom
+pif.sm5.pal.rom
 cmodel
 cmodel.*
 !cmodel.[hc]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
-pif.sm5.rom: pif.sm5.asm
-	@bass -strict -o $@ $^
+roms: pif.sm5.ntsc.rom pif.sm5.pal.rom
 	@sha256sum -c sha256sums.txt
+
+pif.sm5.ntsc.rom: pif.sm5.asm
+	@bass -strict -c region=0 -o $@ $^
+
+pif.sm5.pal.rom: pif.sm5.asm
+	@bass -strict -c region=1 -o $@ $^
 
 CFLAGS = -g -Wall -Wextra -Wpedantic
 
@@ -12,6 +17,6 @@ run: cmodel
 	./cmodel input.txt
 
 clean:
-	rm -f pif.sm5.rom cmodel cmodel.o
+	rm -f pif.sm5.ntsc.rom pif.sm5.pal.rom cmodel cmodel.o
 
 -include user.mk

--- a/cmodel.c
+++ b/cmodel.c
@@ -12,10 +12,9 @@
 // Non-goals:
 // - model every register and memory state transition
 // - model timing
+// - require specific CIC region
 
 FILE* input;
-
-bool reset = 0;
 
 void checkInterrupt(void);
 
@@ -97,10 +96,17 @@ enum {
   PIF_CMD_L_TERMINATE = 3,
 };
 
+bool reset = 0;
+bool regionPAL = 0;  // compile time constant in real PIF ROMs
+
 // The only non-code data in the ROM, taken from 04:00.
-const u8 rom[] = {
+const u8 romNTSC[] = {
     0x19, 0x4a, 0xf1, 0x88, 0xb5, 0x5a, 0x71,
     0xc3, 0xde, 0x61, 0x10, 0xed, 0x9e, 0x8c,
+};
+const u8 romPAL[] = {
+    0x14, 0x2f, 0x35, 0xf1, 0x82, 0x21, 0x77,
+    0x11, 0x99, 0x88, 0x15, 0x17, 0x55, 0xca,
 };
 
 void start(void);
@@ -160,16 +166,17 @@ void start(void) {
   memZero(PIF_CHECKSUM);
 
   cicReadNibble(STATUS);
-  switch (RAM(STATUS)) {
-    case 1:
-      RAM(STATUS) = BIT(OSINFO_VERSION);
-      break;
-    case 9:
+  if ((RAM(STATUS) & 3) == 1) {
+    // N.B. real PIF ROMs only accept one region
+    regionPAL = RAM_BIT_TEST(STATUS, 2);
+
+    if (RAM_BIT_TEST(STATUS, 3)) {
       RAM(STATUS) = BIT(OSINFO_VERSION) | BIT(OSINFO_64DD);
-      break;
-    default:
-      signalError();
-      break;
+    } else {
+      RAM(STATUS) = BIT(OSINFO_VERSION);
+    }
+  } else {
+    signalError();
   }
 
   for (u8 address = RAM_EXTERNAL; address != 0; address += 0x10)
@@ -358,7 +365,7 @@ void cicCompare(void) {
   if (!offset)
     offset = 1;
 
-  for (; offset < 0x10; ++offset) {
+  for (; (offset & 0xf) != 0; offset += (regionPAL ? -1 : +1)) {
     cicWriteBit(RAM_BIT_TEST(CIC_COMPARE_LO + offset, 0));
     bool c = cicReadBit();
     if (c != RAM_BIT_TEST(CIC_COMPARE_HI + offset, 0)) {
@@ -921,7 +928,7 @@ void cicCompareRound(u8 address) {
 void cicCompareExpandSeed(void) {
   RAM(CIC_COMPARE_LO) = 0;
   for (u8 offset = 2; offset < 0x10; ++offset) {
-    u8 byte = rom[RAM(CIC_COMPARE_LO)];
+    u8 byte = (regionPAL ? romPAL : romNTSC)[RAM(CIC_COMPARE_LO)];
     RAM(CIC_COMPARE_LO) += 1;
     RAM(CIC_COMPARE_LO + offset) = byte & 0xf;
     RAM(CIC_COMPARE_HI + offset) = byte >> 4;

--- a/cmodel.c
+++ b/cmodel.c
@@ -12,7 +12,6 @@
 // Non-goals:
 // - model every register and memory state transition
 // - model timing
-// - require specific CIC region
 
 FILE* input;
 
@@ -166,10 +165,7 @@ void start(void) {
   memZero(PIF_CHECKSUM);
 
   cicReadNibble(STATUS);
-  if ((RAM(STATUS) & 3) == 1) {
-    // N.B. real PIF ROMs only accept one region
-    regionPAL = RAM_BIT_TEST(STATUS, 2);
-
+  if ((RAM(STATUS) & 3) == 1 && RAM_BIT_TEST(STATUS, 2) == regionPAL) {
     if (RAM_BIT_TEST(STATUS, 3)) {
       RAM(STATUS) = BIT(OSINFO_VERSION) | BIT(OSINFO_64DD);
     } else {
@@ -1011,6 +1007,13 @@ void writeIO(u8 port, u8 value) {
   printf("w %x %x\n", port, value);
 }
 
+void readRegion(void) {
+  printf("r region\n");
+  int value = scanValue();
+  printf("  %x\n", value);
+  regionPAL = value;
+}
+
 void readCommand(void) {
   printf("r cmd\n");
   int value = scanValue();
@@ -1035,5 +1038,6 @@ int main(int argc, char* argv[]) {
   } else {
     input = stdin;
   }
+  readRegion();
   start();
 }

--- a/input.txt
+++ b/input.txt
@@ -1,3 +1,5 @@
+# Simulate NTSC region PIF
+0
 # P5 handshake - NTSC region
 0 0 0 8
 # P5 seed - CIC 6102

--- a/sha256sums.txt
+++ b/sha256sums.txt
@@ -1,1 +1,3 @@
-ad92d22509e8267cedb3c8a6e48b46a96022e281fabf2c4dc00c1066ab74c801  pif.sm5.rom
+ad92d22509e8267cedb3c8a6e48b46a96022e281fabf2c4dc00c1066ab74c801 *pif.sm5.ntsc.rom
+# Undumped
+e47d437b140d5f21fa5b0ca13c3c3008bfb7fef885363bf83bd0c208c1fb894c *pif.sm5.pal.rom


### PR DESCRIPTION
The PAL version of the ROM is undumped as of yet, so the ROM produced here is speculative in nature. Nevertheless, it should work with PAL CICs and given how constrained the changes are, there's a nonzero chance it matches the true PAL ROM.

The C model now queries which region to simulate before execution begins.